### PR TITLE
Set jvmTarget for compileTestKotlin to 11 also

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -15,3 +15,9 @@ repositories {
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin")
 }
+
+tasks.compileTestKotlin {
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+}

--- a/buildSrc/src/main/kotlin/io.github.seggan.myxal.kotlin-common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/io.github.seggan.myxal.kotlin-common-conventions.gradle.kts
@@ -40,9 +40,19 @@ tasks.compileJava {
     targetCompatibility = "11"
 }
 
-tasks.compileKotlin {
-    kotlinOptions {
-        jvmTarget = "11"
-        freeCompilerArgs = freeCompilerArgs + listOf("-Xno-param-assertions", "-Xjvm-default=all-compatibility")
+val kotlinCompilerArgs = listOf("-Xno-param-assertions", "-Xjvm-default=all-compatibility")
+
+tasks {
+    compileKotlin {
+        kotlinOptions {
+            jvmTarget = "11"
+            freeCompilerArgs += kotlinCompilerArgs
+        }
+    }
+    compileTestKotlin {
+        kotlinOptions {
+            jvmTarget = "11"
+            freeCompilerArgs += kotlinCompilerArgs
+        }
     }
 }


### PR DESCRIPTION
Set the JVM target for the `compileTestKotlin` task to 11 (this was already done for `compileKotlin`). This'll stop Gradle from whining about the target being different from that of the `compileTestJava` task.